### PR TITLE
adds User's models and controllers

### DIFF
--- a/CCCPharma/.gitignore
+++ b/CCCPharma/.gitignore
@@ -23,3 +23,4 @@
 /dist/
 /nbdist/
 /.nb-gradle/
+/bin/

--- a/CCCPharma/src/main/java/br/edu/ufcg/ccc/psoft/cccpharma/CCCPharma/controller/product/UserController.java
+++ b/CCCPharma/src/main/java/br/edu/ufcg/ccc/psoft/cccpharma/CCCPharma/controller/product/UserController.java
@@ -1,0 +1,32 @@
+package br.edu.ufcg.ccc.psoft.cccpharma.CCCPharma.controller.product;
+
+import org.springframework.lang.NonNull;
+
+import br.edu.ufcg.ccc.psoft.cccpharma.CCCPharma.model.product.LoginAlreadyInUseException;
+import br.edu.ufcg.ccc.psoft.cccpharma.CCCPharma.model.user.User;
+import br.edu.ufcg.ccc.psoft.cccpharma.CCCPharma.model.user.UserCollection;
+
+public class UserController {
+	UserCollection users;
+	
+	public UserController() {
+		users = new UserCollection();
+	}
+	
+	public void addUser(@NonNull String name, @NonNull String login, @NonNull String password, @NonNull boolean isAdmin)
+			throws LoginAlreadyInUseException {
+		users.addUser(name, login, password, isAdmin);
+	}
+	
+	public boolean checkRegistered(@NonNull String login) {
+		return users.checkRegistered(login);
+	}
+	
+	private User getUserByLogin(@NonNull String login) {
+		return users.getUserByLogin(login);
+	}
+	
+	private boolean checkPermission(@NonNull String login) {
+		return users.checkPermission(login);
+	}
+}

--- a/CCCPharma/src/main/java/br/edu/ufcg/ccc/psoft/cccpharma/CCCPharma/model/product/LoginAlreadyInUseException.java
+++ b/CCCPharma/src/main/java/br/edu/ufcg/ccc/psoft/cccpharma/CCCPharma/model/product/LoginAlreadyInUseException.java
@@ -1,0 +1,16 @@
+package br.edu.ufcg.ccc.psoft.cccpharma.CCCPharma.model.product;
+
+import org.springframework.lang.NonNull;
+
+public class LoginAlreadyInUseException extends Exception {
+	private static final long serialVersionUID = 1L;
+	
+	private String login;
+	public LoginAlreadyInUseException(@NonNull String _login) {
+		this.login = _login;
+	}
+	
+	public String getLogin() {
+		return login;
+	}
+}

--- a/CCCPharma/src/main/java/br/edu/ufcg/ccc/psoft/cccpharma/CCCPharma/model/user/User.java
+++ b/CCCPharma/src/main/java/br/edu/ufcg/ccc/psoft/cccpharma/CCCPharma/model/user/User.java
@@ -1,0 +1,63 @@
+package br.edu.ufcg.ccc.psoft.cccpharma.CCCPharma.model.user;
+
+import org.springframework.lang.NonNull;
+
+public class User {
+	private String name;
+	private String login;
+	private String password;
+	private boolean isAdmin;
+	
+	public User(@NonNull String _name, @NonNull String _login, @NonNull String _password, boolean _isAdmin) {
+		this.name = _name;
+		this.login = _login;
+		this.password = _password;
+		this.isAdmin = _isAdmin;
+	}
+	
+	public String getName() {
+		return name;
+	}
+	
+	public String getLogin() {
+		return login;
+	}
+	
+	public boolean isAdmin() {
+		return isAdmin;
+	}
+
+	public boolean checkPassword(@NonNull String maybePassword) {
+		return password.equals(maybePassword);
+	}
+	
+	private void setPassword(@NonNull String newPassword) {
+		password = newPassword;
+	}
+	
+	public boolean changePassword(@NonNull String oldPassword, @NonNull String newPassword) {
+		if (checkPassword(oldPassword)) {
+			setPassword(newPassword);
+			return true;
+		}
+		return false;
+	}
+	
+	@Override
+	public int hashCode() {
+		final int prime = 73;
+		int result = 1;
+		result = prime * result + ((login == null) ? 0 : login.hashCode());
+		result = prime * result + ((password == null) ? 0 : password.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if (null != other && other instanceof User) {
+			User otherUser = (User) other;
+			return login.equals(otherUser.login) && password.equals(otherUser.password);
+		}
+		return false;
+	}
+}

--- a/CCCPharma/src/main/java/br/edu/ufcg/ccc/psoft/cccpharma/CCCPharma/model/user/UserCollection.java
+++ b/CCCPharma/src/main/java/br/edu/ufcg/ccc/psoft/cccpharma/CCCPharma/model/user/UserCollection.java
@@ -1,0 +1,39 @@
+package br.edu.ufcg.ccc.psoft.cccpharma.CCCPharma.model.user;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.lang.NonNull;
+
+import br.edu.ufcg.ccc.psoft.cccpharma.CCCPharma.model.product.LoginAlreadyInUseException;
+
+public class UserCollection {
+	Map<String, User> users;
+	
+	public UserCollection() {
+		users = new HashMap<>();
+	}
+	
+	public void addUser(@NonNull String name, @NonNull String login, @NonNull String password, boolean isAdmin) 
+			throws LoginAlreadyInUseException {
+		if (users.containsKey(login)) {
+			throw new LoginAlreadyInUseException(login);
+		}
+		users.put(login, new User(name, login, password, isAdmin));
+	}
+	
+	public boolean checkRegistered(@NonNull String login) {
+		return users.containsKey(login);
+	}
+	
+	public User getUserByLogin(@NonNull String login) {
+		return users.get(login);
+	}
+	
+	public boolean checkPermission(@NonNull String login) {
+		return getUserByLogin(login).isAdmin();
+	}
+}
+
+
+


### PR DESCRIPTION
Durante a implementação, tentei restringir ao máximo possível os dados que podem ser acesador por cada classe.
Ninguém podendo acessar diretamente o password do usuário além da própria classe usuário e o objeto User "subindo" até somente UserController.

Algumas coisas divergem do modelo proposto:
+ boolean checkPermission(boolean) -> boolean checkPermission(String)*
+ login()/logout() -> removed**
+ public getPassword -> private getPassword
+ adicionei um checkPassword(maybePassword) e um changePassword(oldPass, newPass)

*A ideia do método que recebe o boolean dizendo que é algo restrito ao admin, minha sugestão é mudar para um polimorfismo com uma classe PrivilegiesValidator com duas subclasses, uma verificando se é admin e outra inicialmente só validando que o usuário existe

**Manter esse controle manualmente seria um overhead desnecessário no código, acho melhor não mexermos com isso. Porém, acho que é válido adicionar um validateLogin(User, Password) pra tentar autenticar o usuário.